### PR TITLE
Fix vram cycle patterns so that NBG2 & NBG3 display corretly

### DIFF
--- a/vdp2-all-nbgs/vdp2-all-nbgs.c
+++ b/vdp2-all-nbgs/vdp2-all-nbgs.c
@@ -103,14 +103,14 @@ main(void)
         };
 
         const vdp2_vram_cycp_t vram_cycp = {
-                .pt[0].t0 = VDP2_VRAM_CYCP_CHPNDR_NBG0,
-                .pt[0].t1 = VDP2_VRAM_CYCP_CHPNDR_NBG0,
-                .pt[0].t2 = VDP2_VRAM_CYCP_CHPNDR_NBG1,
-                .pt[0].t3 = VDP2_VRAM_CYCP_CHPNDR_NBG1,
-                .pt[0].t4 = VDP2_VRAM_CYCP_CHPNDR_NBG2,
-                .pt[0].t5 = VDP2_VRAM_CYCP_CHPNDR_NBG2,
-                .pt[0].t6 = VDP2_VRAM_CYCP_CHPNDR_NBG3,
-                .pt[0].t7 = VDP2_VRAM_CYCP_CHPNDR_NBG3,
+                .pt[0].t0 = VDP2_VRAM_CYCP_CHPNDR_NBG2,
+                .pt[0].t1 = VDP2_VRAM_CYCP_CHPNDR_NBG2,
+                .pt[0].t2 = VDP2_VRAM_CYCP_CHPNDR_NBG3,
+                .pt[0].t3 = VDP2_VRAM_CYCP_CHPNDR_NBG3,
+                .pt[0].t4 = VDP2_VRAM_CYCP_CHPNDR_NBG0,
+                .pt[0].t5 = VDP2_VRAM_CYCP_CHPNDR_NBG0,
+                .pt[0].t6 = VDP2_VRAM_CYCP_CHPNDR_NBG1,
+                .pt[0].t7 = VDP2_VRAM_CYCP_CHPNDR_NBG1,
 
                 .pt[1].t0 = VDP2_VRAM_CYCP_PNDR_NBG0,
                 .pt[1].t1 = VDP2_VRAM_CYCP_PNDR_NBG0,


### PR DESCRIPTION
... on real hardware

The cycle patterns used in the vdp2-all-nbg example do not follow the constraints for VRAM selection listed in ST-58-R2-060194 (VDP2 Users Manual) p.34 Table 3.4, this PR changes VRAM timing to follow the selection constraints.