### PR TITLE
Change dbgio_dev_deinit() -> dbgio_init() for example to run

### DIFF
--- a/cd-block/cd-block.c
+++ b/cd-block/cd-block.c
@@ -42,7 +42,7 @@ main(void)
         cdfs_filelist_init(&_filelist, filelist_entries, -1);
         cdfs_filelist_root_read(&_filelist);
 
-        dbgio_dev_deinit();
+        dbgio_init();
         dbgio_dev_default_init(DBGIO_DEV_VDP2_ASYNC);
         dbgio_dev_font_load();
 


### PR DESCRIPTION
Previously dbgio initialization happened in user_init, when this was moved into main() the incorrect dbgio method was being called to init the subsystem causing a runtime error, this PR fixes the dbgio method to call for initialization. 